### PR TITLE
made connection parameter optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "illuminate/support": ">5.4",
     "aws/aws-sdk-php": "^3.20.6",
-    "cocur/slugify": "^4.1"
+    "cocur/slugify": "4"
   },
   "require-dev": {
     "mockery/mockery": "^0.9.6",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   },
   "require": {
     "illuminate/support": ">5.4",
-    "aws/aws-sdk-php": "^3.20.6"
+    "aws/aws-sdk-php": "^3.20.6",
+    "cocur/slugify": "^4.1"
   },
   "require-dev": {
     "mockery/mockery": "^0.9.6",

--- a/src/Queues/BatchQueue.php
+++ b/src/Queues/BatchQueue.php
@@ -12,6 +12,7 @@
 namespace DNXLabs\LaravelQueueAwsBatch\Queues;
 
 use Aws\Batch\BatchClient;
+use Cocur\Slugify\Slugify;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
@@ -99,9 +100,10 @@ class BatchQueue extends DatabaseQueue
             $parameters['connectionId'] = $data->connection;
         }
 
+        $slugify = new Slugify();
         $this->batch->submitJob([
             'jobDefinition' => $this->jobDefinition,
-            'jobName'       => $jobName,
+            'jobName'       =>  $slugify->slugify($jobName), // certain chars are not allowed in AWS batch for the job name
             'jobQueue'      => $this->getQueue($queue),
             'parameters'    => $parameters
         ]);

--- a/src/Queues/BatchQueue.php
+++ b/src/Queues/BatchQueue.php
@@ -90,14 +90,20 @@ class BatchQueue extends DatabaseQueue
         $json = json_decode($payload);
         $data = unserialize($json->data->command);
 
+        $parameters = [
+            'jobId' => $jobId,
+        ];
+
+        if(!empty($data->connection)){
+            // $data->connection seems to have been made optional in newer Laravel versions
+            $parameters['connectionId'] = $data->connection;
+        }
+
         $this->batch->submitJob([
             'jobDefinition' => $this->jobDefinition,
             'jobName'       => $jobName,
             'jobQueue'      => $this->getQueue($queue),
-            'parameters'    => [
-                'jobId'        => $jobId,
-                'connectionId' => $data->connection
-            ]
+            'parameters'    => $parameters
         ]);
 
         return $jobId;


### PR DESCRIPTION
When you do not specify a queue connection in the dispatch method (and thus use the default connection) the `connection` field is not present in job data variable.  In this case `connectionId ` will be null and this causes a validation error in the AWS SDK